### PR TITLE
ListMessages: return a list of MessageBase, instead of a list of strings

### DIFF
--- a/lib/core/view_model/list_messages_view_model.py
+++ b/lib/core/view_model/list_messages_view_model.py
@@ -10,7 +10,9 @@ class ListMessagesViewModel(BaseViewModel):
     View Model for the List Messages Feature. Represents all messages in the database for a given conversation.
     """
 
-    message_list: List[str] = Field(description="List of all messages in the database for a given conversation.")
+    message_list: List[MessageBase] = Field(
+        description="List of all messages in the database for a given conversation."
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/lib/infrastructure/presenter/list_messages_presenter.py
+++ b/lib/infrastructure/presenter/list_messages_presenter.py
@@ -16,12 +16,8 @@ class ListMessagesPresenter(ListMessagesOutputPort):
         )
 
     def convert_response_to_view_model(self, response: ListMessagesResponse) -> ListMessagesViewModel:
-        message_list = []
-        if len(response.message_list) > 0:
-            message_list = [msg.to_json() for msg in response.message_list]
-
         return ListMessagesViewModel(
             status=True,
             code=200,
-            message_list=message_list,
+            message_list=response.message_list,
         )


### PR DESCRIPTION
Fix #117

Only ListMessages had the problem of returning str instead of using pydantic models.