### PR TITLE
Feature 122 extend research context

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,6 +83,14 @@ features:
     enabled: true
     auth: true
 
+  Extend_research_context:
+    name: "Extend Research Context"
+    description: "Create a new research context incorporating source data from an existing context with new source data from the client"
+    version: "1.0.0"
+    tags: ["client"]
+    enabled: true
+    auth: true
+
   new_conversation:
     name: "Create Conversation"
     description: "Create a new conversation in a research context"

--- a/config.yaml
+++ b/config.yaml
@@ -83,7 +83,7 @@ features:
     enabled: true
     auth: true
 
-  Extend_research_context:
+  extend_research_context:
     name: "Extend Research Context"
     description: "Create a new research context incorporating source data from an existing context with new source data from the client"
     version: "1.0.0"

--- a/lib/core/ports/primary/extend_research_context_primary_ports.py
+++ b/lib/core/ports/primary/extend_research_context_primary_ports.py
@@ -8,7 +8,7 @@ from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextRequest,
     ExtendResearchContextResponse,
 )
-from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.core.view_model.extend_research_context_view_model import ExtendResearchContextViewModel
 
 
 class ExtendResearchContextInputPort(
@@ -38,14 +38,16 @@ class ExtendResearchContextInputPort(
 
 
 class ExtendResearchContextOutputPort(
-    BasePresenter[ExtendResearchContextResponse, ExtendResearchContextError, NewResearchContextViewModel]
+    BasePresenter[ExtendResearchContextResponse, ExtendResearchContextError, ExtendResearchContextViewModel]
 ):
     @abstractmethod
-    def convert_error_response_to_view_model(self, response: ExtendResearchContextError) -> NewResearchContextViewModel:
+    def convert_error_response_to_view_model(
+        self, response: ExtendResearchContextError
+    ) -> ExtendResearchContextViewModel:
         raise NotImplementedError(
             "You must implement the convert_error_response_to_view_model method in your presenter"
         )
 
     @abstractmethod
-    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> NewResearchContextViewModel:
+    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> ExtendResearchContextViewModel:
         raise NotImplementedError("You must implement the convert_response_to_view_model method in your presenter")

--- a/lib/core/ports/primary/extend_research_context_primary_ports.py
+++ b/lib/core/ports/primary/extend_research_context_primary_ports.py
@@ -1,0 +1,51 @@
+from abc import abstractmethod
+from lib.core.ports.secondary.client_repository import ClientRepositoryOutputPort
+from lib.core.ports.secondary.research_context_repository import ResearchContextRepositoryOutputPort
+from lib.core.sdk.presenter import BasePresenter
+from lib.core.sdk.usecase import BaseUseCase
+from lib.core.usecase_models.extend_research_context_usecase_models import (
+    ExtendResearchContextError,
+    ExtendResearchContextRequest,
+    ExtendResearchContextResponse,
+)
+from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+
+
+class ExtendResearchContextInputPort(
+    BaseUseCase[ExtendResearchContextRequest, ExtendResearchContextResponse, ExtendResearchContextError]
+):
+    def __init__(
+        self,
+        client_repository: ClientRepositoryOutputPort,
+        research_context_repository: ResearchContextRepositoryOutputPort,
+    ) -> None:
+        self._client_repository = client_repository
+        self._research_context_repository = research_context_repository
+
+    @property
+    def client_repository(self) -> ClientRepositoryOutputPort:
+        return self._client_repository
+
+    @property
+    def research_context_repository(self) -> ResearchContextRepositoryOutputPort:
+        return self._research_context_repository
+
+    @abstractmethod
+    def execute(
+        self, request: ExtendResearchContextRequest
+    ) -> ExtendResearchContextResponse | ExtendResearchContextError:
+        raise NotImplementedError("This method must be implemented by the usecase.")
+
+
+class ExtendResearchContextOutputPort(
+    BasePresenter[ExtendResearchContextResponse, ExtendResearchContextError, NewResearchContextViewModel]
+):
+    @abstractmethod
+    def convert_error_response_to_view_model(self, response: ExtendResearchContextError) -> NewResearchContextViewModel:
+        raise NotImplementedError(
+            "You must implement the convert_error_response_to_view_model method in your presenter"
+        )
+
+    @abstractmethod
+    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> NewResearchContextViewModel:
+        raise NotImplementedError("You must implement the convert_response_to_view_model method in your presenter")

--- a/lib/core/usecase/extend_research_context_usecase.py
+++ b/lib/core/usecase/extend_research_context_usecase.py
@@ -89,7 +89,7 @@ class ExtendResearchContextUseCase(ExtendResearchContextInputPort):
                     errorType="UnauthorizedSourceData",
                 )
 
-            # 3. Ensure that there are actually new data sources, and deduplicate as needed
+            # 3. Ensure that there's actually a research context, new data sources, and deduplicate as needed
 
             new_authorized_source_data_ids = [
                 sd_id for sd_id in new_source_data_ids_req if sd_id in authorized_source_data_ids
@@ -104,9 +104,9 @@ class ExtendResearchContextUseCase(ExtendResearchContextInputPort):
             if not isinstance(existing_client_source_data_list, list):
                 return ExtendResearchContextError(
                     errorCode=404,
-                    errorMessage=f"Source Data for existing research context couldn't be retrieved for client with SUB {retrieved_client.sub}.",
-                    errorName="Existing Source Data Not Retrieved",
-                    errorType="ExistingSourceDataNotRetrieved",
+                    errorMessage=f"Research context {existing_research_context_id} not found. Please provide a valid ID for an existing research context.",
+                    errorName="Existing Research Context Not Found",
+                    errorType="ExistingResearchContectNotFound",
                 )
 
             existing_client_source_data_ids = [sd.id for sd in existing_client_source_data_list]

--- a/lib/core/usecase/extend_research_context_usecase.py
+++ b/lib/core/usecase/extend_research_context_usecase.py
@@ -1,0 +1,149 @@
+from lib.core.dto.client_repository_dto import GetClientDTO, ListSourceDataDTO, NewResearchContextDTO
+from lib.core.dto.research_context_repository_dto import ListSourceDataDTO as ResearchContextListSourceDataDTO
+from lib.core.ports.primary.extend_research_context_primary_ports import ExtendResearchContextInputPort
+from lib.core.usecase_models.extend_research_context_usecase_models import (
+    ExtendResearchContextError,
+    ExtendResearchContextRequest,
+    ExtendResearchContextResponse,
+)
+
+
+class ExtendResearchContextUseCase(ExtendResearchContextInputPort):
+    def execute(
+        self, request: ExtendResearchContextRequest
+    ) -> ExtendResearchContextResponse | ExtendResearchContextError:
+        try:
+            client_repository = self.client_repository
+            research_context_repository = self.research_context_repository
+
+            new_research_context_title = request.new_research_context_title
+            new_research_context_description = request.new_research_context_description
+            client_sub = request.client_sub
+            llm_name = request.llm_name
+            new_source_data_ids_req = request.new_source_data_ids
+            existing_research_context_id = request.existing_research_context_id
+
+            # 1. Get the client, by SUB, to then check if they have access to the source data
+            client_by_sub_dto: GetClientDTO = client_repository.get_client_by_sub(client_sub=client_sub)
+
+            if not client_by_sub_dto.status:
+                return ExtendResearchContextError(
+                    errorCode=client_by_sub_dto.errorCode,
+                    errorMessage=client_by_sub_dto.errorMessage,
+                    errorName=client_by_sub_dto.errorName,
+                    errorType=client_by_sub_dto.errorType,
+                )
+
+            retrieved_client = client_by_sub_dto.data
+
+            if not retrieved_client:
+                return ExtendResearchContextError(
+                    errorCode=404,
+                    errorMessage=f"Client with SUB {client_sub} not found.",
+                    errorName="ClientNotFound",
+                    errorType="ClientNotFound",
+                )
+
+            if not retrieved_client.sub == client_sub:
+                return ExtendResearchContextError(
+                    errorCode=403,
+                    errorMessage=f"Client SUB mismatch! Requested: {client_sub}, Retrieved: {retrieved_client.sub}",
+                    errorName="Client SUB Mismatch",
+                    errorType="ClientSubMismatch",
+                )
+
+            # 2. Check if the client has access to the source data
+            new_client_source_data_list_dto: ListSourceDataDTO = client_repository.list_source_data(
+                client_id=retrieved_client.id
+            )
+
+            if not new_client_source_data_list_dto.status:
+                return ExtendResearchContextError(
+                    errorCode=new_client_source_data_list_dto.errorCode,
+                    errorMessage=new_client_source_data_list_dto.errorMessage,
+                    errorName=new_client_source_data_list_dto.errorName,
+                    errorType=new_client_source_data_list_dto.errorType,
+                )
+
+            new_client_source_data_list = new_client_source_data_list_dto.data
+
+            if len(new_client_source_data_list) == 0:
+                return ExtendResearchContextError(
+                    errorCode=404,
+                    errorMessage=f"New Source Data couldn't be retrieved for client with SUB {retrieved_client.sub}.",
+                    errorName="NewSourceDataNotRetrieved",
+                    errorType="NewSourceDataNotRetrieved",
+                )
+
+            authorized_new_source_data_ids = [sd.id for sd in new_client_source_data_list]
+
+            unauthorized_new_source_data_ids = [
+                sd_id for sd_id in new_source_data_ids_req if sd_id not in authorized_new_source_data_ids
+            ]
+
+            if len(unauthorized_new_source_data_ids) > 0:
+                return ExtendResearchContextError(
+                    errorCode=403,
+                    errorMessage=f"Client with SUB {retrieved_client.sub} is not authorized to access the following source data ids: {unauthorized_new_source_data_ids}",
+                    errorName="UnauthorizedSourceData",
+                    errorType="UnauthorizedSourceData",
+                )
+
+            # 3. Ensure that there are actually new data sources, and deduplicate as needed
+
+            existing_client_source_data_list_dto: ResearchContextListSourceDataDTO = (
+                research_context_repository.list_source_data(research_context_id=existing_research_context_id)
+            )
+
+            existing_client_source_data_list = existing_client_source_data_list_dto.data
+
+            if not isinstance(existing_client_source_data_list, list):
+                return ExtendResearchContextError(
+                    errorCode=404,
+                    errorMessage=f"Source Data for existing research context couldn't be retrieved for client with SUB {retrieved_client.sub}.",
+                    errorName="Existing Source Data Not Retrieved",
+                    errorType="ExistingSourceDataNotRetrieved",
+                )
+
+            existing_client_source_data_ids = [sd.id for sd in existing_client_source_data_list]
+
+            extending_client_source_data_ids = [
+                sd_id for sd_id in existing_client_source_data_ids if sd_id not in authorized_new_source_data_ids
+            ]
+
+            if len(extending_client_source_data_ids) == 0:
+                return ExtendResearchContextError(
+                    errorCode=400,
+                    errorMessage="No new source data provided! A new research context requires at least one data source not already found in the referenced existing research context.",
+                    errorName="No New Source Data",
+                    errorType="NoNewSourceData",
+                )
+
+            final_source_data_list = authorized_new_source_data_ids + extending_client_source_data_ids
+
+            # 4. Create the new research context including all (deduplicated) data sources, new and old
+            dto: NewResearchContextDTO = client_repository.new_research_context(
+                research_context_title=new_research_context_title,
+                research_context_description=new_research_context_description,
+                client_sub=client_sub,
+                llm_name=llm_name,
+                source_data_ids=final_source_data_list,
+            )
+
+            if dto.status:
+                return ExtendResearchContextResponse(research_context=dto.research_context, llm=dto.llm)
+
+            return ExtendResearchContextError(
+                errorCode=dto.errorCode,
+                errorMessage=dto.errorMessage,
+                errorName=dto.errorName,
+                errorType=dto.errorType,
+            )
+
+        except Exception as e:
+            return ExtendResearchContextError(
+                errorCode="500",
+                errorMessage=f"Internal Server Error: {e}",
+                errorName="Internal Server Error",
+                errorType="InternalServerError",
+            )

--- a/lib/core/usecase_models/extend_research_context_usecase_models.py
+++ b/lib/core/usecase_models/extend_research_context_usecase_models.py
@@ -1,0 +1,47 @@
+from typing import List
+from pydantic import Field
+from lib.core.entity.models import LLM, ResearchContext
+from lib.core.sdk.usecase_models import BaseErrorResponse, BaseRequest, BaseResponse
+
+
+class ExtendResearchContextRequest(BaseRequest):
+    """
+    Request Model for the Use Case where a Research Context is Extended beyond its original data sources.
+
+    @param new_research_context_title: Title of the new research context to be created to include new data sources.
+    @param client_sub: SUB of the client for which the research context is to be created.
+    @param llm_name: Name of the LLM for which the research context is to be created.
+    @param new_source_data_ids: List of additional source data ids beyond those in the original research context.
+    @param existing_research_context_id: ID of the existing research context to be extended.
+    """
+
+    new_research_context_title: str = Field(
+        description="Title of the new research context to be created to include new data sources."
+    )
+    new_research_context_description: str = Field(description="Description of the research context to be created.")
+    client_sub: str = Field(description="SUB of the client for which the research context is to be created.")
+    llm_name: str = Field(description="Name of the LLM for which the research context is to be created.")
+    new_source_data_ids: List[int] = Field(
+        description="List of additional source data ids beyond those in the original research context."
+    )
+    existing_research_context_id: int = Field(description="ID of the existing research context to be extended.")
+
+
+class ExtendResearchContextResponse(BaseResponse):
+    """
+    Response Model for the Use Case where a Research Context is Extended beyond its original data sources.
+
+    @param research_context: The newly created research context.
+    @param llm: The LLM of the newly created research context.
+    """
+
+    research_context: ResearchContext = Field(description="The newly created research context.")
+    llm: LLM = Field(description="The LLM of the newly created research context.")
+
+
+class ExtendResearchContextError(BaseErrorResponse):
+    """
+    Error Response Model for the Use Case where a Research Context is Extended beyond its original data sources.
+    """
+
+    pass

--- a/lib/core/view_model/extend_research_context_view_model.py
+++ b/lib/core/view_model/extend_research_context_view_model.py
@@ -1,0 +1,26 @@
+from pydantic import Field
+from lib.core.sdk.viewmodel import BaseViewModel
+
+
+class ExtendResearchContextViewModel(BaseViewModel):
+    """
+    View Model for the Extend Research Context Feature.
+    """
+
+    research_context_id: int = Field(description="ID of the newly created research context.")
+    research_context_title: str = Field(description="Title of the newly created research context.")
+    research_context_description: str = Field(description="Description of the newly created research context.")
+    llm_name: str = Field(description="Name of the LLM of the newly created research context.")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "research_context_id": 1,
+                    "research_context_title": "My Super Cool Research Context",
+                    "research_context_description": "This Research Context is particularly cool.",
+                    "llm_name": "llama2",
+                }
+            ]
+        }
+    }

--- a/lib/infrastructure/config/containers.py
+++ b/lib/infrastructure/config/containers.py
@@ -19,6 +19,9 @@ from lib.infrastructure.config.features.list_source_data_for_research_context_fe
 from lib.infrastructure.config.features.new_conversation_feature_container import NewConversationFeatureContainer
 from lib.infrastructure.config.features.new_message_feature_container import NewMessageFeatureContainer
 from lib.infrastructure.config.features.new_research_context_feature_container import NewResearchContextFeatureContainer
+from lib.infrastructure.config.features.extend_research_context_feature_container import (
+    ExtendResearchContextFeatureContainer,
+)
 from lib.infrastructure.config.features.new_source_data_feature_container import NewSourceDataFeatureContainer
 from lib.infrastructure.config.features.get_client_data_for_upload_feature_container import (
     GetClientDataForUploadFeatureContainer,
@@ -132,6 +135,13 @@ class ApplicationContainer(containers.DeclarativeContainer):
         NewResearchContextFeatureContainer,
         config=config.features.new_research_context,
         client_repository=sqla_client_repository,
+    )
+
+    extend_research_context_feature = providers.Container(
+        ExtendResearchContextFeatureContainer,
+        config=config.features.extend_research_context,
+        client_repository=sqla_client_repository,
+        research_context_repository=sqla_research_context_repository,
     )
 
     new_conversation_feature = providers.Container(

--- a/lib/infrastructure/config/features/extend_research_context_feature_container.py
+++ b/lib/infrastructure/config/features/extend_research_context_feature_container.py
@@ -1,0 +1,32 @@
+from typing import Any
+from lib.core.ports.primary.extend_research_context_primary_ports import (
+    ExtendResearchContextInputPort,
+    ExtendResearchContextOutputPort,
+)
+from lib.core.sdk.ioc_feature_container import BaseFeatureContainer
+
+from dependency_injector import providers
+
+from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
+
+# from lib.infrastructure.controller.new_message_controller import NewMessageController
+# from lib.infrastructure.presenter.new_message_presenter import NewMessagePresenter
+
+
+class ExtendResearchContextFeatureContainer(BaseFeatureContainer):
+    client_repository: Any = providers.Dependency()
+    research_context_repository: Any = providers.Dependency()
+
+    # presenter = providers.Factory[NewMessageOutputPort](NewMessagePresenter)
+
+    usecase = providers.Factory[ExtendResearchContextInputPort](
+        ExtendResearchContextUseCase,
+        client_repository=client_repository,
+        research_context_repository=research_context_repository,
+    )
+
+    # controller = providers.Factory(
+    #     NewMessageController,
+    #     usecase=usecase,
+    #     presenter=presenter,
+    # )

--- a/lib/infrastructure/config/features/extend_research_context_feature_container.py
+++ b/lib/infrastructure/config/features/extend_research_context_feature_container.py
@@ -1,5 +1,4 @@
 from typing import Any
-from lib.core.ports.primary.new_research_context_primary_ports import NewResearchContextOutputPort
 from lib.core.ports.primary.extend_research_context_primary_ports import (
     ExtendResearchContextInputPort,
     ExtendResearchContextOutputPort,
@@ -11,14 +10,14 @@ from dependency_injector import providers
 from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
 
 from lib.infrastructure.controller.extend_research_context_controller import ExtendResearchContextController
-from lib.infrastructure.presenter.new_research_context_presenter import NewResearchContextPresenter
+from lib.infrastructure.presenter.extend_research_context_presenter import ExtendResearchContextPresenter
 
 
 class ExtendResearchContextFeatureContainer(BaseFeatureContainer):
     client_repository: Any = providers.Dependency()
     research_context_repository: Any = providers.Dependency()
 
-    presenter = providers.Factory[NewResearchContextOutputPort](NewResearchContextPresenter)
+    presenter = providers.Factory[ExtendResearchContextOutputPort](ExtendResearchContextPresenter)
 
     usecase = providers.Factory[ExtendResearchContextInputPort](
         ExtendResearchContextUseCase,

--- a/lib/infrastructure/config/features/extend_research_context_feature_container.py
+++ b/lib/infrastructure/config/features/extend_research_context_feature_container.py
@@ -1,4 +1,5 @@
 from typing import Any
+from lib.core.ports.primary.new_research_context_primary_ports import NewResearchContextOutputPort
 from lib.core.ports.primary.extend_research_context_primary_ports import (
     ExtendResearchContextInputPort,
     ExtendResearchContextOutputPort,
@@ -9,15 +10,15 @@ from dependency_injector import providers
 
 from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
 
-# from lib.infrastructure.controller.new_message_controller import NewMessageController
-# from lib.infrastructure.presenter.new_message_presenter import NewMessagePresenter
+from lib.infrastructure.controller.extend_research_context_controller import ExtendResearchContextController
+from lib.infrastructure.presenter.new_research_context_presenter import NewResearchContextPresenter
 
 
 class ExtendResearchContextFeatureContainer(BaseFeatureContainer):
     client_repository: Any = providers.Dependency()
     research_context_repository: Any = providers.Dependency()
 
-    # presenter = providers.Factory[NewMessageOutputPort](NewMessagePresenter)
+    presenter = providers.Factory[NewResearchContextOutputPort](NewResearchContextPresenter)
 
     usecase = providers.Factory[ExtendResearchContextInputPort](
         ExtendResearchContextUseCase,
@@ -25,8 +26,8 @@ class ExtendResearchContextFeatureContainer(BaseFeatureContainer):
         research_context_repository=research_context_repository,
     )
 
-    # controller = providers.Factory(
-    #     NewMessageController,
-    #     usecase=usecase,
-    #     presenter=presenter,
-    # )
+    controller = providers.Factory(
+        ExtendResearchContextController,
+        usecase=usecase,
+        presenter=presenter,
+    )

--- a/lib/infrastructure/controller/extend_research_context_controller.py
+++ b/lib/infrastructure/controller/extend_research_context_controller.py
@@ -7,7 +7,7 @@ from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextRequest,
     ExtendResearchContextResponse,
 )
-from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.core.view_model.extend_research_context_view_model import ExtendResearchContextViewModel
 from lib.infrastructure.presenter.extend_research_context_presenter import ExtendResearchContextPresenter
 
 
@@ -44,7 +44,7 @@ class ExtendResearchContextController(
         ExtendResearchContextRequest,
         ExtendResearchContextResponse,
         ExtendResearchContextError,
-        NewResearchContextViewModel,
+        ExtendResearchContextViewModel,
     ]
 ):
     def __init__(

--- a/lib/infrastructure/controller/extend_research_context_controller.py
+++ b/lib/infrastructure/controller/extend_research_context_controller.py
@@ -1,0 +1,70 @@
+from fastapi import HTTPException
+from pydantic import Field
+from lib.core.sdk.controller import BaseController, BaseControllerParameters
+from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
+from lib.core.usecase_models.extend_research_context_usecase_models import (
+    ExtendResearchContextError,
+    ExtendResearchContextRequest,
+    ExtendResearchContextResponse,
+)
+from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.infrastructure.presenter.extend_research_context_presenter import ExtendResearchContextPresenter
+
+
+class ExtendResearchContextControllerParameters(BaseControllerParameters):
+    new_research_context_title: str = Field(
+        title="Research Context Title",
+        description="Title of the new research context to be created to include new data sources.",
+    )
+    new_research_context_description: str = Field(
+        title="Research Context Description",
+        description="Description of the research context to be created.",
+    )
+    client_sub: str = Field(
+        title="Client SUB",
+        description="SUB of the client for which the research context is to be created.",
+    )
+    llm_name: str = Field(
+        title="LLM Name",
+        description="Name of the LLM for which the research context is to be created.",
+    )
+    new_source_data_ids: list[int] = Field(
+        title="Source Data IDs",
+        description="List of additional source data ids beyond those in the original research context.",
+    )
+    existing_research_context_id: int = Field(
+        title="Existing Research Context ID",
+        description="ID of the existing research context to be extended.",
+    )
+
+
+class ExtendResearchContextController(
+    BaseController[
+        ExtendResearchContextControllerParameters,
+        ExtendResearchContextRequest,
+        ExtendResearchContextResponse,
+        ExtendResearchContextError,
+        NewResearchContextViewModel,
+    ]
+):
+    def __init__(
+        self,
+        usecase: ExtendResearchContextUseCase,
+        presenter: ExtendResearchContextPresenter,
+    ) -> None:
+        super().__init__(usecase=usecase, presenter=presenter)
+
+    def create_request(
+        self, parameters: ExtendResearchContextControllerParameters | None
+    ) -> ExtendResearchContextRequest:
+        if parameters is None:
+            raise HTTPException(status_code=400, detail="Invalid request parameters.")
+        else:
+            return ExtendResearchContextRequest(
+                new_research_context_title=parameters.new_research_context_title,
+                new_research_context_description=parameters.new_research_context_description,
+                client_sub=parameters.client_sub,
+                llm_name=parameters.llm_name,
+                new_source_data_ids=parameters.new_source_data_ids,
+                existing_research_context_id=parameters.existing_research_context_id,
+            )

--- a/lib/infrastructure/presenter/extend_research_context_presenter.py
+++ b/lib/infrastructure/presenter/extend_research_context_presenter.py
@@ -1,0 +1,36 @@
+from lib.core.ports.primary.extend_research_context_primary_ports import ExtendResearchContextOutputPort
+from lib.core.usecase_models.extend_research_context_usecase_models import (
+    ExtendResearchContextError,
+    ExtendResearchContextResponse,
+)
+from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+
+
+class ExtendResearchContextPresenter(ExtendResearchContextOutputPort):
+    def convert_error_response_to_view_model(self, response: ExtendResearchContextError) -> NewResearchContextViewModel:
+        return NewResearchContextViewModel(
+            status=False,
+            code=response.errorCode,
+            errorCode=response.errorCode,
+            errorMessage=response.errorMessage,
+            errorName=response.errorName,
+            errorType=response.errorType,
+            research_context_id=-1,
+            research_context_title="",
+            research_context_description="",
+            llm_name="",
+        )
+
+    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> NewResearchContextViewModel:
+        research_context_id = response.research_context.id
+        research_context_title = response.research_context.title
+        llm_name = response.llm.llm_name
+
+        return NewResearchContextViewModel(
+            status=True,
+            code=200,
+            research_context_id=research_context_id,
+            research_context_title=research_context_title,
+            research_context_description=response.research_context.description,
+            llm_name=llm_name,
+        )

--- a/lib/infrastructure/presenter/extend_research_context_presenter.py
+++ b/lib/infrastructure/presenter/extend_research_context_presenter.py
@@ -3,12 +3,14 @@ from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextError,
     ExtendResearchContextResponse,
 )
-from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.core.view_model.extend_research_context_view_model import ExtendResearchContextViewModel
 
 
 class ExtendResearchContextPresenter(ExtendResearchContextOutputPort):
-    def convert_error_response_to_view_model(self, response: ExtendResearchContextError) -> NewResearchContextViewModel:
-        return NewResearchContextViewModel(
+    def convert_error_response_to_view_model(
+        self, response: ExtendResearchContextError
+    ) -> ExtendResearchContextViewModel:
+        return ExtendResearchContextViewModel(
             status=False,
             code=response.errorCode,
             errorCode=response.errorCode,
@@ -21,12 +23,12 @@ class ExtendResearchContextPresenter(ExtendResearchContextOutputPort):
             llm_name="",
         )
 
-    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> NewResearchContextViewModel:
+    def convert_response_to_view_model(self, response: ExtendResearchContextResponse) -> ExtendResearchContextViewModel:
         research_context_id = response.research_context.id
         research_context_title = response.research_context.title
         llm_name = response.llm.llm_name
 
-        return NewResearchContextViewModel(
+        return ExtendResearchContextViewModel(
             status=True,
             code=200,
             research_context_id=research_context_id,

--- a/lib/infrastructure/rest/endpoints/extend_research_context_fastapi_endpoints.py
+++ b/lib/infrastructure/rest/endpoints/extend_research_context_fastapi_endpoints.py
@@ -1,0 +1,64 @@
+from typing import Any
+from lib.core.sdk.fastapi import FastAPIEndpoint
+from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.infrastructure.config.containers import ApplicationContainer
+from lib.infrastructure.controller.extend_research_context_controller import ExtendResearchContextControllerParameters
+
+from dependency_injector.wiring import inject, Provide
+
+
+class ExtendResearchContextFastAPIFeature(
+    FastAPIEndpoint[ExtendResearchContextControllerParameters, NewResearchContextViewModel]
+):
+    @inject
+    def __init__(
+        self,
+        descriptor: Any = Provide[ApplicationContainer.extend_research_context_feature.feature_descriptor],
+        controller: Any = Provide[ApplicationContainer.extend_research_context_feature.controller],
+    ):
+        responses: dict[int | str, dict[str, Any]] = {
+            200: {
+                "model": NewResearchContextViewModel,
+                "description": "Success",
+            },
+            400: {
+                "model": NewResearchContextViewModel,
+                "description": "Bad Request.",
+            },
+            500: {
+                "model": NewResearchContextViewModel,
+                "description": "Internal Server Error",
+            },
+        }
+
+        super().__init__(controller=controller, descriptor=descriptor, responses=responses)
+
+    def register_endpoint(self) -> None:
+        @self.router.post(
+            name=self.name,
+            description=self.descriptor.description,
+            path="/research-context/extend",
+            responses=self.responses,
+        )
+        def endpoint(
+            new_research_context_title: str,
+            new_research_context_description: str,
+            new_source_data_ids: list[int],
+            existing_research_context_id: int,
+            client_sub: str,
+            llm_name: str,
+        ) -> NewResearchContextViewModel | None:
+            controller_parameters = ExtendResearchContextControllerParameters(
+                new_research_context_title=new_research_context_title,
+                new_research_context_description=new_research_context_description,
+                existing_research_context_id=existing_research_context_id,
+                client_sub=client_sub,
+                llm_name=llm_name,
+                new_source_data_ids=new_source_data_ids,
+            )
+
+            view_model: NewResearchContextViewModel = self.execute(
+                controller_parameters=controller_parameters,
+            )
+
+            return view_model

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -1,5 +1,6 @@
 import random
 import uuid
+from typing import List
 from faker import Faker
 from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
 from lib.core.usecase_models.extend_research_context_usecase_models import (
@@ -7,6 +8,11 @@ from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextResponse,
 )
 from lib.infrastructure.config.containers import ApplicationContainer
+from lib.infrastructure.controller.extend_research_context_controller import (
+    ExtendResearchContextController,
+    ExtendResearchContextControllerParameters,
+)
+from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
 from lib.infrastructure.repository.sqla.database import TDatabaseFactory
 from lib.infrastructure.repository.sqla.models import (
     SQLALLM,
@@ -41,10 +47,10 @@ def test_extend_research_context_usecase(
         existing_source_data_ids.extend([sd.id for sd in context.source_data])
 
     incoming_source_data_list = fake_source_data_list
-    new_source_data_list = []
+    new_source_data_list: List[SQLASourceData] = []
     for source_data in incoming_source_data_list:
-        # while source_data.id is None or source_data.id in existing_source_data_ids:
-        source_data.id = source_data.id or random.randint(1001, 2000)
+        while source_data.id is None or source_data.id in existing_source_data_ids + new_source_data_list:
+            source_data.id = random.randint(1001, 2000)
         new_source_data_list.append(source_data)
     client_with_context.source_data.extend(new_source_data_list)
     new_source_data_ids = [sd.id for sd in new_source_data_list]
@@ -94,6 +100,107 @@ def test_extend_research_context_usecase(
         assert response.research_context is not None
 
         queried_new_research_context = session.get(SQLAResearchContext, response.research_context.id)
+
+        assert queried_new_research_context is not None
+
+        queried_new_research_context_source_data_list = queried_new_research_context.source_data
+        queried_new_research_context_source_data_ids = [sd.id for sd in queried_new_research_context_source_data_list]
+
+        existing_source_data_overlap_check = [
+            sd.id
+            for sd in queried_existing_research_context.source_data
+            if sd.id not in queried_new_research_context_source_data_ids
+        ]
+
+        assert len(existing_source_data_overlap_check) == 0
+
+        new_source_data_overlap_check = [
+            sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids
+        ]
+
+        assert len(new_source_data_overlap_check) == 0
+
+        # Check uniqueness
+        assert len(queried_new_research_context_source_data_ids) == len(
+            set(queried_new_research_context_source_data_ids)
+        )
+
+
+def test_extend_research_context_controller(
+    app_initialization_container: ApplicationContainer,
+    db_session: TDatabaseFactory,
+    fake: Faker,
+    fake_client_with_conversation: SQLAClient,
+    fake_source_data_list: list[SQLAResearchContext],
+) -> None:
+    controller: ExtendResearchContextController = (
+        app_initialization_container.extend_research_context_feature.controller()
+    )
+
+    assert controller is not None
+
+    client_with_context = fake_client_with_conversation
+    llm_name = fake.name()
+
+    # Make sure all source data have valid, unique IDs
+    existing_source_data_ids = []
+    for context in client_with_context.research_contexts:
+        existing_source_data_ids.extend([sd.id for sd in context.source_data])
+
+    incoming_source_data_list = fake_source_data_list
+    new_source_data_list: List[SQLASourceData] = []
+    for source_data in incoming_source_data_list:
+        while source_data.id is None or source_data.id in existing_source_data_ids + new_source_data_list:
+            source_data.id = random.randint(2001, 3000)
+        new_source_data_list.append(source_data)
+    client_with_context.source_data.extend(new_source_data_list)
+    new_source_data_ids = [sd.id for sd in new_source_data_list]
+
+    llm = SQLALLM(
+        llm_name=llm_name,
+        research_contexts=client_with_context.research_contexts,
+    )
+
+    existing_research_context = random.choice(client_with_context.research_contexts)
+    # Make titles unique to query later
+    existing_research_context_title = f"{existing_research_context.title}-{uuid.uuid4()}"
+    existing_research_context.title = existing_research_context_title
+
+    with db_session() as session:
+        client_with_context.save(session=session, flush=True)
+        session.commit()
+
+    with db_session() as session:
+        queried_existing_research_context = (
+            session.query(SQLAResearchContext).filter_by(title=existing_research_context_title).first()
+        )
+
+        assert queried_existing_research_context is not None
+
+        queried_client = session.get(SQLAClient, queried_existing_research_context.client_id)
+
+        assert queried_client is not None
+
+        # Details for new Research Context data
+        new_research_context_title = f"{fake.name().replace(' ', '_')}-{uuid.uuid4()}"
+        new_research_context_description = f"{fake.text()}-{uuid.uuid4()}"
+
+        controller_parameters = ExtendResearchContextControllerParameters(
+            new_research_context_title=new_research_context_title,
+            new_research_context_description=new_research_context_description,
+            client_sub=queried_client.sub,
+            llm_name=llm_name,
+            new_source_data_ids=new_source_data_ids,
+            existing_research_context_id=queried_existing_research_context.id,
+        )
+        view_model = controller.execute(parameters=controller_parameters)
+
+        assert view_model is not None
+        assert isinstance(view_model, NewResearchContextViewModel)
+
+        assert view_model.research_context_id is not None
+
+        queried_new_research_context = session.get(SQLAResearchContext, view_model.research_context_id)
 
         assert queried_new_research_context is not None
 

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -1,0 +1,101 @@
+import random
+import uuid
+from faker import Faker
+from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
+from lib.core.usecase_models.extend_research_context_models import (
+    ExtendResearchContextRequest,
+    ExtendResearchContextResponse,
+)
+from lib.infrastructure.config.containers import ApplicationContainer
+from lib.infrastructure.repository.sqla.database import TDatabaseFactory
+from lib.infrastructure.repository.sqla.models import (
+    SQLALLM,
+    SQLAResearchContext,
+    SQLAClient,
+)
+
+
+def test_extend_research_context(
+    app_initialization_container: ApplicationContainer,
+    db_session: TDatabaseFactory,
+    fake: Faker,
+    fake_client_with_research_context: SQLAClient,
+) -> None:
+    usecase: ExtendResearchContextUseCase = app_initialization_container.extend_research_context_feature.usecase()
+
+    assert usecase is not None
+
+    client_with_context = fake_client_with_research_context
+    llm = SQLALLM(
+        llm_name=fake.name(),
+        research_contexts=client_with_context.research_contexts,
+    )
+
+    assert len(client_with_context.research_contexts) > 1
+
+    existing_research_context = random.choice(client_with_context.research_contexts)
+    remaining_research_contexts = [
+        rc for rc in client_with_context.research_contexts if rc.id != existing_research_context.id
+    ]
+    new_research_context = random.choice(remaining_research_contexts)
+    # Make titles unique to query later
+    existing_research_context_title = f"{existing_research_context.title}-{uuid.uuid4()}"
+    existing_research_context.title = existing_research_context_title
+
+    with db_session() as session:
+        client_with_context.save(session=session, flush=True)
+        session.commit()
+
+    # Details for new Research Context data
+    new_research_context_title = f"{new_research_context.title}-{uuid.uuid4()}"
+    new_research_context_description = f"{fake.text()}-{uuid.uuid4()}"
+    new_source_data_list = new_research_context.source_data
+    new_source_data_ids = [sd.id for sd in new_source_data_list]
+
+    with db_session() as session:
+        queried_existing_research_context = (
+            session.query(SQLAResearchContext).filter_by(title=existing_research_context_title).first()
+        )
+
+        assert queried_existing_research_context is not None
+
+        request = ExtendResearchContextRequest(
+            new_research_context_title=new_research_context_title,
+            new_research_context_description=new_research_context_description,
+            client_sub=fake_client_with_research_context.sub,
+            llm_name=llm,
+            new_source_data_ids=new_source_data_ids,
+            existing_research_context_id=queried_existing_research_context.id,
+        )
+        response = usecase.execute(request=request)
+
+        assert response is not None
+        assert isinstance(response, ExtendResearchContextResponse)
+
+        assert response.research_context is not None
+
+        queried_new_research_context = session.get(SQLAResearchContext, response.research_context.id)
+
+        assert queried_new_research_context is not None
+
+        queried_new_research_context_source_data_list = queried_new_research_context.source_data
+        queried_new_research_context_source_data_ids = [sd.id for sd in queried_new_research_context_source_data_list]
+
+        existing_source_data_overlap_check = [
+            sd.id
+            for sd in queried_existing_research_context.source_data
+            if sd.id not in queried_new_research_context_source_data_ids
+        ]
+
+        assert len(existing_source_data_overlap_check) == 0
+
+        new_source_data_overlap_check = [
+            sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids
+        ]
+
+        assert len(new_source_data_overlap_check) == 0
+
+        # Check uniqueness
+        assert len(queried_new_research_context_source_data_ids) == len(
+            set(queried_new_research_context_source_data_ids)
+        )

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -16,7 +16,12 @@ from lib.infrastructure.repository.sqla.models import (
 )
 
 
-def test_extend_research_context(
+def test_extend_research_context_presenter(app_container: ApplicationContainer) -> None:
+    presenter = app_container.extend_research_context_feature.presenter()
+    assert presenter is not None
+
+
+def test_extend_research_context_usecase(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -12,7 +12,7 @@ from lib.infrastructure.controller.extend_research_context_controller import (
     ExtendResearchContextController,
     ExtendResearchContextControllerParameters,
 )
-from lib.core.view_model.new_research_context_view_mode import NewResearchContextViewModel
+from lib.core.view_model.extend_research_context_view_model import ExtendResearchContextViewModel
 from lib.infrastructure.repository.sqla.database import TDatabaseFactory
 from lib.infrastructure.repository.sqla.models import (
     SQLALLM,
@@ -31,14 +31,14 @@ def test_extend_research_context_usecase(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,
-    fake_client_with_research_context_and_new_sources: SQLAClient,  # Fake client with Research Context
+    fake_client_with_research_context_and_sources: SQLAClient,  # Fake client with Research Context
     fake_source_data_list: list[SQLAResearchContext],
 ) -> None:
     usecase: ExtendResearchContextUseCase = app_initialization_container.extend_research_context_feature.usecase()
 
     assert usecase is not None
 
-    client_with_context = fake_client_with_research_context_and_new_sources
+    client_with_context = fake_client_with_research_context_and_sources
     llm_name = fake.name()
 
     existing_research_context = random.choice(client_with_context.research_contexts)
@@ -120,7 +120,7 @@ def test_extend_research_context_usecase(
             if sd_id not in queried_existing_source_data_ids
         ]
 
-        assert len(extending_source_data_check) != 0
+        assert len(extending_source_data_check) > 0
 
         new_source_data_overlap_check = [
             sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids
@@ -138,7 +138,7 @@ def test_extend_research_context_controller(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,
-    fake_client_with_research_context_and_new_sources: SQLAClient,
+    fake_client_with_research_context_and_sources: SQLAClient,
     fake_source_data_list: list[SQLAResearchContext],
 ) -> None:
     controller: ExtendResearchContextController = (
@@ -147,7 +147,7 @@ def test_extend_research_context_controller(
 
     assert controller is not None
 
-    client_with_context = fake_client_with_research_context_and_new_sources
+    client_with_context = fake_client_with_research_context_and_sources
     llm_name = fake.name()
 
     existing_research_context = random.choice(client_with_context.research_contexts)
@@ -161,7 +161,7 @@ def test_extend_research_context_controller(
     new_source_data_list: List[SQLASourceData] = []
     for source_data in incoming_source_data_list:
         while source_data.id is None or source_data.id in existing_source_data_ids + new_source_data_list:
-            source_data.id = random.randint(1001, 2000)
+            source_data.id = random.randint(2001, 3000)
         new_source_data_list.append(source_data)
 
     client_with_context.source_data.extend(new_source_data_list)
@@ -210,7 +210,7 @@ def test_extend_research_context_controller(
         view_model = controller.execute(parameters=controller_parameters)
 
         assert view_model is not None
-        assert isinstance(view_model, NewResearchContextViewModel)
+        assert isinstance(view_model, ExtendResearchContextViewModel)
 
         assert view_model.research_context_id is not None
 
@@ -229,7 +229,7 @@ def test_extend_research_context_controller(
             if sd_id not in queried_existing_source_data_ids
         ]
 
-        assert len(extending_source_data_check) == 0
+        assert len(extending_source_data_check) > 0
 
         new_source_data_overlap_check = [
             sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -31,20 +31,22 @@ def test_extend_research_context_usecase(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,
-    fake_client_with_conversation: SQLAClient,  # Fake client with Research Context
+    fake_client_with_research_context_and_new_sources: SQLAClient,  # Fake client with Research Context
     fake_source_data_list: list[SQLAResearchContext],
 ) -> None:
     usecase: ExtendResearchContextUseCase = app_initialization_container.extend_research_context_feature.usecase()
 
     assert usecase is not None
 
-    client_with_context = fake_client_with_conversation
+    client_with_context = fake_client_with_research_context_and_new_sources
     llm_name = fake.name()
 
-    # Make sure all source data have valid, unique IDs
+    existing_research_context = random.choice(client_with_context.research_contexts)
+    # Populate source data into the existing research context
     existing_source_data_ids = []
-    for context in client_with_context.research_contexts:
-        existing_source_data_ids.extend([sd.id for sd in context.source_data])
+    for source_datum in client_with_context.source_data:
+        existing_research_context.source_data.append(source_datum)
+        existing_source_data_ids.append(source_datum.id)
 
     incoming_source_data_list = fake_source_data_list
     new_source_data_list: List[SQLASourceData] = []
@@ -52,16 +54,17 @@ def test_extend_research_context_usecase(
         while source_data.id is None or source_data.id in existing_source_data_ids + new_source_data_list:
             source_data.id = random.randint(1001, 2000)
         new_source_data_list.append(source_data)
+
     client_with_context.source_data.extend(new_source_data_list)
     new_source_data_ids = [sd.id for sd in new_source_data_list]
+    assert new_source_data_ids != []
 
     llm = SQLALLM(
         llm_name=llm_name,
         research_contexts=client_with_context.research_contexts,
     )
 
-    existing_research_context = random.choice(client_with_context.research_contexts)
-    # Make titles unique to query later
+    # Make title unique to query later
     existing_research_context_title = f"{existing_research_context.title}-{uuid.uuid4()}"
     existing_research_context.title = existing_research_context_title
 
@@ -75,6 +78,9 @@ def test_extend_research_context_usecase(
         )
 
         assert queried_existing_research_context is not None
+        queried_existing_source_data_list = queried_existing_research_context.source_data
+        queried_existing_source_data_ids = [sd.id for sd in queried_existing_source_data_list]
+        assert queried_existing_source_data_ids != new_source_data_ids
 
         queried_client = session.get(SQLAClient, queried_existing_research_context.client_id)
 
@@ -102,17 +108,19 @@ def test_extend_research_context_usecase(
         queried_new_research_context = session.get(SQLAResearchContext, response.research_context.id)
 
         assert queried_new_research_context is not None
+        assert queried_new_research_context.title == new_research_context_title
+        assert queried_new_research_context.description == new_research_context_description
 
         queried_new_research_context_source_data_list = queried_new_research_context.source_data
         queried_new_research_context_source_data_ids = [sd.id for sd in queried_new_research_context_source_data_list]
 
-        existing_source_data_overlap_check = [
-            sd.id
-            for sd in queried_existing_research_context.source_data
-            if sd.id not in queried_new_research_context_source_data_ids
+        extending_source_data_check = [
+            sd_id
+            for sd_id in queried_new_research_context_source_data_ids
+            if sd_id not in queried_existing_source_data_ids
         ]
 
-        assert len(existing_source_data_overlap_check) == 0
+        assert len(extending_source_data_check) != 0
 
         new_source_data_overlap_check = [
             sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids
@@ -130,7 +138,7 @@ def test_extend_research_context_controller(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,
-    fake_client_with_conversation: SQLAClient,
+    fake_client_with_research_context_and_new_sources: SQLAClient,
     fake_source_data_list: list[SQLAResearchContext],
 ) -> None:
     controller: ExtendResearchContextController = (
@@ -139,29 +147,32 @@ def test_extend_research_context_controller(
 
     assert controller is not None
 
-    client_with_context = fake_client_with_conversation
+    client_with_context = fake_client_with_research_context_and_new_sources
     llm_name = fake.name()
 
-    # Make sure all source data have valid, unique IDs
+    existing_research_context = random.choice(client_with_context.research_contexts)
+    # Populate source data into the existing research context
     existing_source_data_ids = []
-    for context in client_with_context.research_contexts:
-        existing_source_data_ids.extend([sd.id for sd in context.source_data])
+    for source_datum in client_with_context.source_data:
+        existing_research_context.source_data.append(source_datum)
+        existing_source_data_ids.append(source_datum.id)
 
     incoming_source_data_list = fake_source_data_list
     new_source_data_list: List[SQLASourceData] = []
     for source_data in incoming_source_data_list:
         while source_data.id is None or source_data.id in existing_source_data_ids + new_source_data_list:
-            source_data.id = random.randint(2001, 3000)
+            source_data.id = random.randint(1001, 2000)
         new_source_data_list.append(source_data)
+
     client_with_context.source_data.extend(new_source_data_list)
     new_source_data_ids = [sd.id for sd in new_source_data_list]
+    assert new_source_data_ids != []
 
     llm = SQLALLM(
         llm_name=llm_name,
         research_contexts=client_with_context.research_contexts,
     )
 
-    existing_research_context = random.choice(client_with_context.research_contexts)
     # Make titles unique to query later
     existing_research_context_title = f"{existing_research_context.title}-{uuid.uuid4()}"
     existing_research_context.title = existing_research_context_title
@@ -176,6 +187,9 @@ def test_extend_research_context_controller(
         )
 
         assert queried_existing_research_context is not None
+        queried_existing_source_data_list = queried_existing_research_context.source_data
+        queried_existing_source_data_ids = [sd.id for sd in queried_existing_source_data_list]
+        assert queried_existing_source_data_ids != new_source_data_ids
 
         queried_client = session.get(SQLAClient, queried_existing_research_context.client_id)
 
@@ -203,17 +217,19 @@ def test_extend_research_context_controller(
         queried_new_research_context = session.get(SQLAResearchContext, view_model.research_context_id)
 
         assert queried_new_research_context is not None
+        assert queried_new_research_context.title == new_research_context_title
+        assert queried_new_research_context.description == new_research_context_description
 
         queried_new_research_context_source_data_list = queried_new_research_context.source_data
         queried_new_research_context_source_data_ids = [sd.id for sd in queried_new_research_context_source_data_list]
 
-        existing_source_data_overlap_check = [
-            sd.id
-            for sd in queried_existing_research_context.source_data
-            if sd.id not in queried_new_research_context_source_data_ids
+        extending_source_data_check = [
+            sd_id
+            for sd_id in queried_new_research_context_source_data_ids
+            if sd_id not in queried_existing_source_data_ids
         ]
 
-        assert len(existing_source_data_overlap_check) == 0
+        assert len(extending_source_data_check) == 0
 
         new_source_data_overlap_check = [
             sd_id for sd_id in new_source_data_ids if sd_id not in queried_new_research_context_source_data_ids

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -6,6 +6,7 @@ from lib.core.usecase.extend_research_context_usecase import ExtendResearchConte
 from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextRequest,
     ExtendResearchContextResponse,
+    ExtendResearchContextError,
 )
 from lib.infrastructure.config.containers import ApplicationContainer
 from lib.infrastructure.controller.extend_research_context_controller import (
@@ -133,6 +134,20 @@ def test_extend_research_context_usecase(
             set(queried_new_research_context_source_data_ids)
         )
 
+        redundant_request = ExtendResearchContextRequest(
+            new_research_context_title=new_research_context_title,
+            new_research_context_description=new_research_context_description,
+            client_sub=queried_client.sub,
+            llm_name=llm_name,
+            new_source_data_ids=queried_existing_source_data_ids,
+            existing_research_context_id=queried_existing_research_context.id,
+        )
+        redundant_response = usecase.execute(request=redundant_request)
+
+        assert redundant_response is not None
+        assert isinstance(redundant_response, ExtendResearchContextError)
+        assert redundant_response.errorType == "NoNewSourceData"
+
 
 def test_extend_research_context_controller(
     app_initialization_container: ApplicationContainer,
@@ -241,3 +256,17 @@ def test_extend_research_context_controller(
         assert len(queried_new_research_context_source_data_ids) == len(
             set(queried_new_research_context_source_data_ids)
         )
+
+        redundant_controller_parameters = ExtendResearchContextControllerParameters(
+            new_research_context_title=new_research_context_title,
+            new_research_context_description=new_research_context_description,
+            client_sub=queried_client.sub,
+            llm_name=llm_name,
+            new_source_data_ids=queried_existing_source_data_ids,
+            existing_research_context_id=queried_existing_research_context.id,
+        )
+        redundant_view_model = controller.execute(parameters=redundant_controller_parameters)
+
+        assert redundant_view_model is not None
+        assert isinstance(redundant_view_model, ExtendResearchContextViewModel)
+        assert redundant_view_model.errorType == "NoNewSourceData"

--- a/tests/api/test_extend_research_context_feature.py
+++ b/tests/api/test_extend_research_context_feature.py
@@ -2,7 +2,7 @@ import random
 import uuid
 from faker import Faker
 from lib.core.usecase.extend_research_context_usecase import ExtendResearchContextUseCase
-from lib.core.usecase_models.extend_research_context_models import (
+from lib.core.usecase_models.extend_research_context_usecase_models import (
     ExtendResearchContextRequest,
     ExtendResearchContextResponse,
 )
@@ -11,6 +11,7 @@ from lib.infrastructure.repository.sqla.database import TDatabaseFactory
 from lib.infrastructure.repository.sqla.models import (
     SQLALLM,
     SQLAResearchContext,
+    SQLASourceData,
     SQLAClient,
 )
 
@@ -19,25 +20,36 @@ def test_extend_research_context(
     app_initialization_container: ApplicationContainer,
     db_session: TDatabaseFactory,
     fake: Faker,
-    fake_client_with_research_context: SQLAClient,
+    fake_client_with_conversation: SQLAClient,  # Fake client with Research Context
+    fake_source_data_list: list[SQLAResearchContext],
 ) -> None:
     usecase: ExtendResearchContextUseCase = app_initialization_container.extend_research_context_feature.usecase()
 
     assert usecase is not None
 
-    client_with_context = fake_client_with_research_context
+    client_with_context = fake_client_with_conversation
+    llm_name = fake.name()
+
+    # Make sure all source data have valid, unique IDs
+    existing_source_data_ids = []
+    for context in client_with_context.research_contexts:
+        existing_source_data_ids.extend([sd.id for sd in context.source_data])
+
+    incoming_source_data_list = fake_source_data_list
+    new_source_data_list = []
+    for source_data in incoming_source_data_list:
+        # while source_data.id is None or source_data.id in existing_source_data_ids:
+        source_data.id = source_data.id or random.randint(1001, 2000)
+        new_source_data_list.append(source_data)
+    client_with_context.source_data.extend(new_source_data_list)
+    new_source_data_ids = [sd.id for sd in new_source_data_list]
+
     llm = SQLALLM(
-        llm_name=fake.name(),
+        llm_name=llm_name,
         research_contexts=client_with_context.research_contexts,
     )
 
-    assert len(client_with_context.research_contexts) > 1
-
     existing_research_context = random.choice(client_with_context.research_contexts)
-    remaining_research_contexts = [
-        rc for rc in client_with_context.research_contexts if rc.id != existing_research_context.id
-    ]
-    new_research_context = random.choice(remaining_research_contexts)
     # Make titles unique to query later
     existing_research_context_title = f"{existing_research_context.title}-{uuid.uuid4()}"
     existing_research_context.title = existing_research_context_title
@@ -46,12 +58,6 @@ def test_extend_research_context(
         client_with_context.save(session=session, flush=True)
         session.commit()
 
-    # Details for new Research Context data
-    new_research_context_title = f"{new_research_context.title}-{uuid.uuid4()}"
-    new_research_context_description = f"{fake.text()}-{uuid.uuid4()}"
-    new_source_data_list = new_research_context.source_data
-    new_source_data_ids = [sd.id for sd in new_source_data_list]
-
     with db_session() as session:
         queried_existing_research_context = (
             session.query(SQLAResearchContext).filter_by(title=existing_research_context_title).first()
@@ -59,11 +65,19 @@ def test_extend_research_context(
 
         assert queried_existing_research_context is not None
 
+        queried_client = session.get(SQLAClient, queried_existing_research_context.client_id)
+
+        assert queried_client is not None
+
+        # Details for new Research Context data
+        new_research_context_title = f"{fake.name().replace(' ', '_')}-{uuid.uuid4()}"
+        new_research_context_description = f"{fake.text()}-{uuid.uuid4()}"
+
         request = ExtendResearchContextRequest(
             new_research_context_title=new_research_context_title,
             new_research_context_description=new_research_context_description,
-            client_sub=fake_client_with_research_context.sub,
-            llm_name=llm,
+            client_sub=queried_client.sub,
+            llm_name=llm_name,
             new_source_data_ids=new_source_data_ids,
             existing_research_context_id=queried_existing_research_context.id,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -455,9 +455,13 @@ def client_with_research_context_and_new_sources(
     fake_source_data_init = tuple(source_data() for _ in range(number_of_new_source_data + 1))
     fake_source_data = list(fake_source_data_init)
 
-    client.source_data.extend(fake_source_data)
+    # client.source_data.extend(fake_source_data)
 
-    return client
+    return SQLAClient(
+        sub=client.sub,
+        research_contexts=fake_research_contexts,
+        source_data=fake_source_data,
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,6 +443,28 @@ def fake_client_with_source_data_list() -> List[SQLAClient]:
     return [client_with_source_data() for _ in range(10)]
 
 
+def client_with_research_context_and_new_sources(
+    number_of_research_contexts: int = 2,
+    number_of_new_source_data: int = 3,
+) -> SQLAClient:
+    client = sqla_client()
+
+    fake_research_contexts_init = tuple(research_context() for _ in range(number_of_research_contexts + 1))
+    fake_research_contexts = list(fake_research_contexts_init)
+
+    fake_source_data_init = tuple(source_data() for _ in range(number_of_new_source_data + 1))
+    fake_source_data = list(fake_source_data_init)
+
+    client.source_data.extend(fake_source_data)
+
+    return client
+
+
+@pytest.fixture(scope="function")
+def fake_client_with_research_context_and_new_sources() -> SQLAClient:
+    return client_with_research_context_and_new_sources()
+
+
 def citation() -> SQLACitation:
     fake = Faker().unique
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,7 +443,7 @@ def fake_client_with_source_data_list() -> List[SQLAClient]:
     return [client_with_source_data() for _ in range(10)]
 
 
-def client_with_research_context_and_new_sources(
+def client_with_research_context_and_sources(
     number_of_research_contexts: int = 2,
     number_of_new_source_data: int = 3,
 ) -> SQLAClient:
@@ -465,8 +465,8 @@ def client_with_research_context_and_new_sources(
 
 
 @pytest.fixture(scope="function")
-def fake_client_with_research_context_and_new_sources() -> SQLAClient:
-    return client_with_research_context_and_new_sources()
+def fake_client_with_research_context_and_sources() -> SQLAClient:
+    return client_with_research_context_and_sources()
 
 
 def citation() -> SQLACitation:


### PR DESCRIPTION
Added three new files to handle the Usecase Model, Import Port, and Usecase code for a new feature to allow for extending existing Research Contexts. Since adding new source data to an existing Research Context isn't a practical solution for several reasons, this feature expects that the end user will provide new data sources together with identifying information about the existing Research Context, which the Usecase can then use to create a new Research Context by combining (and deduplicating) the new source data with the source data already present in the provided Research Context.

These files were created by cloning and adapting the corresponding files for the New Research Context feature. Models outside the scope of this training exercise (e.g. View Model) were not updated. A new error was created for the scenario in which no _actually_ new source data is provided (i.e. all provided source data is duplicative of source data already found in the existing Research Context).