### PR TITLE
[TSK-484]  Ugly fix to DB sessions

### DIFF
--- a/lib/infrastructure/repository/sqla/sqla_client_repository.py
+++ b/lib/infrastructure/repository/sqla/sqla_client_repository.py
@@ -39,6 +39,7 @@ class SQLAClientRepository(ClientRepositoryOutputPort):
 
     @property
     def session(self) -> Session:
+        self._session.expire_all()
         return self._session
 
     def get_client(self, client_id: int) -> GetClientDTO:

--- a/lib/infrastructure/repository/sqla/sqla_conversation_repository.py
+++ b/lib/infrastructure/repository/sqla/sqla_conversation_repository.py
@@ -51,7 +51,7 @@ class SQLAConversationRepository(ConversationRepository):
 
     @property
     def session(self) -> Session:
-        #self._session.expire_all()
+        self._session.expire_all()
         return self._session
 
     def get_conversation(self, conversation_id: int) -> GetConversationDTO:
@@ -174,7 +174,6 @@ class SQLAConversationRepository(ConversationRepository):
             return errorDTO
 
         try:
-            #self.session.expire_all()
             sqla_conversation: SQLAConversation | None = self.session.get(SQLAConversation, conversation_id)
 
         except Exception as e:

--- a/lib/infrastructure/repository/sqla/sqla_conversation_repository.py
+++ b/lib/infrastructure/repository/sqla/sqla_conversation_repository.py
@@ -51,6 +51,7 @@ class SQLAConversationRepository(ConversationRepository):
 
     @property
     def session(self) -> Session:
+        #self._session.expire_all()
         return self._session
 
     def get_conversation(self, conversation_id: int) -> GetConversationDTO:
@@ -173,6 +174,7 @@ class SQLAConversationRepository(ConversationRepository):
             return errorDTO
 
         try:
+            #self.session.expire_all()
             sqla_conversation: SQLAConversation | None = self.session.get(SQLAConversation, conversation_id)
 
         except Exception as e:

--- a/lib/infrastructure/repository/sqla/sqla_research_context_repository.py
+++ b/lib/infrastructure/repository/sqla/sqla_research_context_repository.py
@@ -28,6 +28,7 @@ class SQLAReseachContextRepository(ResearchContextRepositoryOutputPort):
 
     @property
     def session(self) -> Session:
+        self._session.expire_all()
         return self._session
 
     def get_research_context(self, research_context_id: int) -> GetResearchContextDTO:

--- a/lib/infrastructure/repository/sqla/sqla_source_data_repository.py
+++ b/lib/infrastructure/repository/sqla/sqla_source_data_repository.py
@@ -21,6 +21,7 @@ class SQLASourceDataRepository(SourceDataRepositoryOutputPort):
 
     @property
     def session(self) -> Session:
+        self._session.expire_all()
         return self._session
 
     def get_source_data_by_composite_index(

--- a/tests/api/test_list_messages_feature.py
+++ b/tests/api/test_list_messages_feature.py
@@ -11,7 +11,14 @@ from lib.infrastructure.controller.list_messages_controller import (
     ListMessagesControllerParameters,
 )
 from lib.infrastructure.repository.sqla.database import TDatabaseFactory
-from lib.infrastructure.repository.sqla.models import SQLALLM, SQLAAgentMessage, SQLAConversation, SQLAResearchContext, SQLAClient, SQLAUserMessage
+from lib.infrastructure.repository.sqla.models import (
+    SQLALLM,
+    SQLAAgentMessage,
+    SQLAConversation,
+    SQLAResearchContext,
+    SQLAClient,
+    SQLAUserMessage,
+)
 
 
 def test_list_messages_usecase(
@@ -19,7 +26,7 @@ def test_list_messages_usecase(
     db_session: TDatabaseFactory,
     fake: Faker,
     fake_client_with_conversation: SQLAClient,
-    fake_message_pair: Tuple[SQLAUserMessage, SQLAAgentMessage]
+    fake_message_pair: Tuple[SQLAUserMessage, SQLAAgentMessage],
 ) -> None:
     usecase: ListMessagesUseCase = app_initialization_container.list_messages_feature.usecase()
 
@@ -60,7 +67,6 @@ def test_list_messages_usecase(
         queried_messages_contents = [piece.content for msg in response.message_list for piece in msg.message_contents]
 
         assert set(queried_messages_contents) == set(messages_contents)
-    
 
     with db_session() as session:
         conv = session.query(SQLAConversation).filter_by(title=conversation_title).first()
@@ -92,9 +98,6 @@ def test_list_messages_usecase(
         queried_messages_contents = [piece.content for msg in response.message_list for piece in msg.message_contents]
 
         assert set(queried_messages_contents) == set(messages_contents)
-
-
-
 
 
 def test_list_messages_controller(

--- a/tests/repositories/sqla_conversation/test_list_conversation_messages.py
+++ b/tests/repositories/sqla_conversation/test_list_conversation_messages.py
@@ -23,7 +23,7 @@ def test_list_conversation_messages(
     db_session: TDatabaseFactory,
     fake: Faker,
     fake_client_with_conversation: SQLAClient,
-    fake_message_pair: Tuple[SQLAUserMessage, SQLAAgentMessage]
+    fake_message_pair: Tuple[SQLAUserMessage, SQLAAgentMessage],
 ) -> None:
     conversation_repository = app_initialization_container.sqla_conversation_repository()
 
@@ -68,7 +68,6 @@ def test_list_conversation_messages(
 
         for piece in message_contents:
             assert piece.content in messages_contents
-    
 
         conv = session.query(SQLAConversation).filter_by(title=conversation_title).first()
 
@@ -84,15 +83,13 @@ def test_list_conversation_messages(
         conv.save(session=session, flush=True)
         session.commit()
 
-
         conv = session.query(SQLAConversation).filter_by(title=conversation_title).first()
 
         assert conv is not None
 
-        new_dto: ListConversationMessagesDTO[
-            MessageBase
-        ] = conversation_repository.list_conversation_messages(conversation_id=conv.id)
-
+        new_dto: ListConversationMessagesDTO[MessageBase] = conversation_repository.list_conversation_messages(
+            conversation_id=conv.id
+        )
 
     assert new_dto.data is not None
     assert new_dto.status == True
@@ -106,10 +103,6 @@ def test_list_conversation_messages(
 
         for piece in new_message_contents:
             assert piece.content in messages_contents
-
-
-
-
 
 
 def test_error_list_conversation_messages_none_conversation_id(


### PR DESCRIPTION
- (Ugly) fixes the problem of not being able to list messages (and potentially everything else) after creating new ones, by doing a .expire_all() in the session of all repositories
- Problem was: after creation of messages, then listing, db session would keep the first batch of messages and only show those for all successive lists, even if you created new messages. For references, see the usecase test in test_list_messages_feature, which breaks without the ugly fix
- Tried: to configure the session factory to have "expire_on_commit = True" (or put that config in different places) to have a more elegant solution, but none of that worked as the .expire_all()