### PR TITLE
[TSK-657] feat: configure `workers` and `allowed_origins` for prod uvicorn

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,8 @@ fastapi:
   port: ${KP_FASTAPI_PORT:8000}
   debug: ${KP_FASTAPI_DEBUG:false}
   reload: ${KP_FASTAPI_RELOAD:false}
+  workers: ${KP_FASTAPI_WORKERS:4}
+  allowed_origins: ${KP_FASTAPI_ALLOWED_ORIGINS}
 
 default_data:
   client_sub: "planckster-example@mpi-sws.org"

--- a/lib/infrastructure/rest/main.py
+++ b/lib/infrastructure/rest/main.py
@@ -224,7 +224,7 @@ def start() -> None:
 
     # Add CORS middleware
     default_origins = ["http://localhost", "http://localhost:3000", "http://localhost:8080"]
-    allowed_origins = os.getenv("KP_ALLOWED_ORIGINS", "").split(",")
+    allowed_origins = os.getenv("KP_FASTAPI_ALLOWED_ORIGINS", "").split(",")
     final_origins = default_origins + [x.strip() for x in allowed_origins if x.strip() != ""]
     print(f"Allowed origins: {final_origins}")
     app.add_middleware(
@@ -236,7 +236,16 @@ def start() -> None:
     )
     host = app.container.config.fastapi.host()  # type: ignore
     port = app.container.config.fastapi.port()  # type: ignore
-    uvicorn.run("lib.infrastructure.rest.main:create_app", host=host, port=port, proxy_headers=True, reload=False)
+    workers = app.container.config.fastapi.workers()  # type: ignore
+
+    uvicorn.run(
+        "lib.infrastructure.rest.main:create_app",
+        host=host,
+        port=port,
+        proxy_headers=True,
+        reload=False,
+        workers=workers,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes changes to the `config.yaml` and `lib/infrastructure/rest/main.py` files to enhance the configuration and startup process of the FastAPI application. The most important changes include adding new configuration options for the number of workers and allowed origins, and updating the startup script to utilize these new options.

Configuration enhancements:

* [`config.yaml`](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034R32-R33): Added new configuration options `workers` and `allowed_origins` to allow setting the number of workers and specifying allowed origins for CORS.

Startup script updates:

* [`lib/infrastructure/rest/main.py`](diffhunk://#diff-1236a87e22e593aa6f3d8ae422812d67441ee28f39a702d0417059b7a136341eL227-R227): Updated the `allowed_origins` variable to use the new `KP_FASTAPI_ALLOWED_ORIGINS` environment variable.
* [`lib/infrastructure/rest/main.py`](diffhunk://#diff-1236a87e22e593aa6f3d8ae422812d67441ee28f39a702d0417059b7a136341eL239-R248): Modified the `uvicorn.run` call to include the new `workers` configuration option, allowing the FastAPI application to run with the specified number of workers.…tAPI #148 TSK-657

Introduced `KP_FASTAPI_ALLOWED_ORIGINS` and `KP_FASTAPI_WORKERS` environment variables to configure CORS and workers settings in FastAPI.

Removed
`KP_ALLOWED_ORIGINS`