### PR TITLE
[TSK-657] refactor: revert Prod CORS config via KP_ALLOWED_ORIGINS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,6 @@ fastapi:
   debug: ${KP_FASTAPI_DEBUG:false}
   reload: ${KP_FASTAPI_RELOAD:false}
   workers: ${KP_FASTAPI_WORKERS:4}
-  allowed_origins: ${KP_FASTAPI_ALLOWED_ORIGINS}
 
 default_data:
   client_sub: "planckster-example@mpi-sws.org"

--- a/lib/infrastructure/rest/main.py
+++ b/lib/infrastructure/rest/main.py
@@ -224,7 +224,7 @@ def start() -> None:
 
     # Add CORS middleware
     default_origins = ["http://localhost", "http://localhost:3000", "http://localhost:8080"]
-    allowed_origins = os.getenv("KP_FASTAPI_ALLOWED_ORIGINS", "").split(",")
+    allowed_origins = os.getenv("KP_ALLOWED_ORIGINS", "").split(",")
     final_origins = default_origins + [x.strip() for x in allowed_origins if x.strip() != ""]
     print(f"Allowed origins: {final_origins}")
     app.add_middleware(


### PR DESCRIPTION
This pull request includes changes to the configuration and environment variable handling for allowed origins in the FastAPI application. The most important changes involve updating the configuration file and the main application script to use a new environment variable.

Configuration updates:

* [`config.yaml`](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L33): Removed the `allowed_origins` configuration entry.

Environment variable handling:

* [`lib/infrastructure/rest/main.py`](diffhunk://#diff-1236a87e22e593aa6f3d8ae422812d67441ee28f39a702d0417059b7a136341eL227-R227): Changed the environment variable from `KP_FASTAPI_ALLOWED_ORIGINS` to `KP_ALLOWED_ORIGINS` for allowed origins in the CORS middleware setup.